### PR TITLE
Added `--binary` argument for sending arbitrary bytes instead of text

### DIFF
--- a/lib/smppsend.ex
+++ b/lib/smppsend.ex
@@ -44,6 +44,7 @@ defmodule SMPPSend do
     udh_part_num: :integer,
 
     ucs2: :boolean,
+	binary: :boolean,
 
     wait_dlrs: :integer,
     wait: :boolean
@@ -63,6 +64,7 @@ defmodule SMPPSend do
     udh_part_num: 1,
 
     ucs2: false,
+	binary: false,
 
     wait: false
   ]
@@ -87,6 +89,7 @@ defmodule SMPPSend do
       &set_defaults/1,
       &show_help/1,
       &validate_missing/1,
+      &decode_hex_string/1,
       &convert_to_ucs2/1,
       &trap_exit/1,
       &bind/1,
@@ -143,6 +146,23 @@ defmodule SMPPSend do
     end
   end
 
+  defp decode_hex_string(opts) do
+    if opts[:binary] do
+      case SMPPSend.OptionHelpers.decode_hex_string(opts, :short_message) do
+        {:ok, new_opts} ->
+          tlvs = opts[:tlvs]
+          {:ok, message_payload_id} = SMPPEX.Protocol.TlvFormat.id_by_name(:message_payload)
+        case SMPPSend.OptionHelpers.decode_hex_string(tlvs, message_payload_id) do
+          {:ok, new_tlvs} -> {:ok, Keyword.put(new_opts, :tlvs, new_tlvs)}
+          {:error, error} -> {:error, "Failed to decode message_payload: #{error}"}
+        end
+        {:error, error} -> {:error, "Failed to decode short_message: #{error}"}
+      end
+    else
+      {:ok, opts}
+    end
+  end
+  
   defp convert_to_ucs2(opts) do
     if opts[:ucs2] do
       case SMPPSend.OptionHelpers.convert_to_ucs2(opts, :short_message) do

--- a/lib/smppsend.ex
+++ b/lib/smppsend.ex
@@ -44,7 +44,7 @@ defmodule SMPPSend do
     udh_part_num: :integer,
 
     ucs2: :boolean,
-	  binary: :boolean,
+    binary: :boolean,
 
     wait_dlrs: :integer,
     wait: :boolean
@@ -64,7 +64,7 @@ defmodule SMPPSend do
     udh_part_num: 1,
 
     ucs2: false,
-	  binary: false,
+    binary: false,
 
     wait: false
   ]

--- a/lib/smppsend.ex
+++ b/lib/smppsend.ex
@@ -44,7 +44,7 @@ defmodule SMPPSend do
     udh_part_num: :integer,
 
     ucs2: :boolean,
-	binary: :boolean,
+	  binary: :boolean,
 
     wait_dlrs: :integer,
     wait: :boolean
@@ -64,7 +64,7 @@ defmodule SMPPSend do
     udh_part_num: 1,
 
     ucs2: false,
-	binary: false,
+	  binary: false,
 
     wait: false
   ]

--- a/lib/smppsend/option_helpers.ex
+++ b/lib/smppsend/option_helpers.ex
@@ -41,7 +41,7 @@ defmodule SMPPSend.OptionHelpers do
 
   defp to_ucs2(str) do
     str
-      |> to_charlist
+      |> to_char_list
       |> :xmerl_ucs.to_ucs2be
       |> to_string
   end

--- a/lib/smppsend/option_helpers.ex
+++ b/lib/smppsend/option_helpers.ex
@@ -18,24 +18,36 @@ defmodule SMPPSend.OptionHelpers do
   def find_missing(opts, required_list) do
     required_list |> Enum.filter(fn(name) -> not Keyword.has_key?(opts, name) end)
   end
-
+  
+  def decode_hex_string(opts, key) do
+    modify_text_opt(opts, key, &to_bytes/1)
+  end
+  
   def convert_to_ucs2(opts, key) do
+    modify_text_opt(opts, key, &to_ucs2/1)
+  end
+  
+  def modify_text_opt(opts, key, modifier) do
     try do
       case List.keyfind(opts, key, 0) do
         {^key, value} ->
-          {:ok, List.keyreplace(opts, key, 0, {key, to_ucs2(value)})}
+          {:ok, List.keyreplace(opts, key, 0, {key, apply(modifier,[value])})}
         nil -> {:ok, opts}
       end
     catch some, error ->
       {:error, inspect({some, error})}
-    end
+    end  
   end
 
   defp to_ucs2(str) do
     str
-      |> to_char_list
+      |> to_charlist
       |> :xmerl_ucs.to_ucs2be
       |> to_string
+  end
+  
+  defp to_bytes(hex_string) do
+    Base.decode16!(hex_string, case: :mixed)
   end
 
 end

--- a/lib/smppsend/usage.ex
+++ b/lib/smppsend/usage.ex
@@ -20,6 +20,8 @@ Available options are:
   --udh                                 Prepend short_message with UDH. This option is incompatible with --split-max-bytes option
 
   --ucs2                                Convert short_message field and message_payload TLV from UTF8 to UCS2 before sending submit_sm PDUs
+  
+  --binary                              Decode short_message field and message_payload TLV from raw hex representation (e.g. input `003100320033` to see `123` in a UCS2 message)
 
   --wait-dlrs y<timeout>                   Wait for for delivery reports for all sent submit_sm PDUs or exit with failure after y<timeout> ms
 

--- a/test/smppsend/option_helpers_test.exs
+++ b/test/smppsend/option_helpers_test.exs
@@ -20,5 +20,19 @@ defmodule SMPPSend.OptionHelpersTest do
   test "convert_to_ucs2, error" do
     assert {:error, _} = convert_to_ucs2([a: <<231, 232>>, b: "пока"], :a)
   end
+  
+  test "decode_hex_string, ok" do
+    assert {:ok, new_list} = decode_hex_string([a: "003100320033", b: "пока"], :a)
+    assert Keyword.equal?([a: <<0, 49, 0, 50, 0, 51>>, b: "пока"], new_list)
+  end
+
+  test "decode_hex_string, length error" do
+    assert {:error, _} = decode_hex_string([a: "123", b: "пока"], :a)
+  end
+  
+  test "decode_hex_string, alphabet error" do
+    assert {:error, _} = decode_hex_string([a: "hello", b: "пока"], :a)
+  end
+  
 end
 


### PR DESCRIPTION
The main motivation for this feature was my need to send null bytes, which had been impossible in a null-terminated strings environment.

If you find this feature appropriate, I will be glad to update the PR according to your feedback.

This is my first experience with the elixir, sorry if the code sucks.