### PR TITLE
Erlang 21 support

### DIFF
--- a/build/17/Dockerfile
+++ b/build/17/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Ilya Averyanov <ilya@averyanov.org>
 
 ENV LANG=en_US.UTF-8
 
-RUN yum install -y https://yum.kaos.io/6/release/i386/kaos-repo-7.0-0.el6.noarch.rpm
+RUN yum install -y https://yum.kaos.st/kaos-repo-latest.el6.noarch.rpm
 RUN yum install -y unzip git erlang17
 
 RUN curl -fSL -o elixir-precompiled.zip https://github.com/elixir-lang/elixir/releases/download/v1.1.1/Precompiled.zip

--- a/build/18/Dockerfile
+++ b/build/18/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Ilya Averyanov <ilya@averyanov.org>
 
 ENV LANG=en_US.UTF-8
 
-RUN yum install -y https://yum.kaos.io/6/release/i386/kaos-repo-7.0-0.el6.noarch.rpm
+RUN yum install -y https://yum.kaos.st/kaos-repo-latest.el6.noarch.rpm
 RUN yum install -y unzip git erlang18
 
 RUN curl -fSL -o elixir-precompiled.zip https://github.com/elixir-lang/elixir/releases/download/v1.4.5/Precompiled.zip

--- a/build/19/Dockerfile
+++ b/build/19/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Ilya Averyanov <ilya@averyanov.org>
 
 ENV LANG=en_US.UTF-8
 
-RUN yum install -y https://yum.kaos.io/6/release/i386/kaos-repo-7.0-0.el6.noarch.rpm
+RUN yum install -y https://yum.kaos.st/kaos-repo-latest.el6.noarch.rpm
 RUN yum install -y unzip git erlang19
 
 RUN curl -fSL -o elixir-precompiled.zip https://github.com/elixir-lang/elixir/releases/download/v1.4.5/Precompiled.zip

--- a/build/20/Dockerfile
+++ b/build/20/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER Ilya Averyanov <ilya@averyanov.org>
 
 ENV LANG=en_US.UTF-8
 
-RUN yum install -y https://yum.kaos.io/6/release/i386/kaos-repo-7.0-0.el6.noarch.rpm
-RUN yum install -y unzip git erlang20 --enablerepo=kaos-testing
+RUN yum install -y https://yum.kaos.st/kaos-repo-latest.el6.noarch.rpm
+RUN yum install -y unzip git erlang20
 
 RUN curl -fSL -o elixir-precompiled.zip https://github.com/elixir-lang/elixir/releases/download/v1.5.1/Precompiled.zip
 

--- a/build/21/Dockerfile
+++ b/build/21/Dockerfile
@@ -1,0 +1,14 @@
+FROM centos:centos6
+
+MAINTAINER Ilya Averyanov <ilya@averyanov.org>
+
+ENV LANG=en_US.UTF-8
+
+RUN yum install -y https://yum.kaos.st/kaos-repo-latest.el6.noarch.rpm
+RUN yum install -y unzip git erlang21
+
+RUN curl -fSL -o elixir-precompiled.zip https://github.com/elixir-lang/elixir/releases/download/v1.9.1/Precompiled.zip
+
+RUN unzip -d /usr/local elixir-precompiled.zip
+RUN mix local.hex --force
+RUN mix local.rebar --force

--- a/build/21/Dockerfile
+++ b/build/21/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:centos6
 
-MAINTAINER Ilya Averyanov <ilya@averyanov.org>
+MAINTAINER Alex Mikka <a.mikka@fun-box.ru>
 
 ENV LANG=en_US.UTF-8
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Smppsend.Mixfile do
   def project do
     [
       app: :smppsend,
-      version: "0.1.15",
+      version: "0.1.16",
       elixir: "~> 1.1",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Hi! 
Here I added Dockerfile with Erlang 21. And fixed kaos-repo rpm url in the rest versions because the old one isn't valid anymore.